### PR TITLE
Fixed tiling issue, removed excessive type casting, added multiprocessing

### DIFF
--- a/polus-label-to-vector-plugin/src/dynamics.py
+++ b/polus-label-to-vector-plugin/src/dynamics.py
@@ -49,9 +49,10 @@ def _extend_centers(T, y, x, ymed, xmed, Lx, niter):
 def labels_to_flows(labels):
     """ Convert labels ( masks or flows) to flows for training model
     Args:
-        labels(array):  Is used to create flows and cell probabilities.
+        labels (array):  Is used to create flows and cell probabilities.
     Returns:
-        flows(array): l[3 x Ly x Lx] arrays flows[1] is cell probability, flows[2] is Y flow, and flows[3] is X flow
+        flows (array): l[3 x Ly x Lx] arrays flows[1] is cell probability,
+            flows[2] is Y flow, and flows[3] is X flow
 
     """
 

--- a/polus-label-to-vector-plugin/src/main.py
+++ b/polus-label-to-vector-plugin/src/main.py
@@ -1,10 +1,47 @@
 from bfio.bfio import BioReader
-import argparse, logging, sys
+import argparse, logging
 import numpy as np
 from pathlib import Path
 import dynamics
 import zarr
-import shutil
+from concurrent.futures import ProcessPoolExecutor, wait
+from multiprocessing import cpu_count
+import matplotlib.pyplot as plt
+
+TILE_SIZE = 2048
+TILE_OVERLAP = 1024
+
+def flow_thread(input_path: Path,
+                zfile: Path,
+                x: int,
+                y: int,
+                z: int) -> bool:
+    
+    root = zarr.open(zfile)
+    
+    with BioReader(input_path) as br:
+        
+        x_min = max([0,x-TILE_OVERLAP])
+        x_max = min([br.X,x+TILE_SIZE+TILE_OVERLAP])
+        
+        y_min = max([0,y-TILE_OVERLAP])
+        y_max = min([br.Y,y+TILE_SIZE+TILE_OVERLAP])
+    
+        flow = dynamics.labels_to_flows(br[y_min:y_max, x_min:x_max,z:z+1, 0,0].squeeze())
+        flow_final = flow[:,:,:,np.newaxis,np.newaxis].transpose(1,2,3,0,4)
+        
+        x_overlap = x - x_min
+        x_min = x
+        x_max = min([br.X,x+TILE_SIZE])
+        
+        y_overlap = y - y_min
+        y_min = y
+        y_max = min([br.Y,y+TILE_SIZE])
+        
+        zfile[f]['vector'][y_min:y_max, x_min:x_max,z:z+1,0:3,0:1] = flow_final[y_overlap:y_max-y_min+y_overlap,x_overlap:x_max-x_min+x_overlap,...]
+        zfile[f]['lbl'][y_min:y_max, x_min:x_max,z:z+1, 0:1,0:1] = br[y_min:y_max, x_min:x_max,z:z+1, 0,0]
+        
+    return True
 
 if __name__=="__main__":
     # Initialize the logger
@@ -23,6 +60,8 @@ if __name__=="__main__":
     # Output arguments
     parser.add_argument('--outDir', dest='outDir', type=str,
                         help='Output collection', required=True)
+    
+    num_threads = max([cpu_count()//2,1])
 
     # Parse the arguments
     args = parser.parse_args()
@@ -34,41 +73,50 @@ if __name__=="__main__":
     outDir = args.outDir
     logger.info('outDir = {}'.format(outDir))
 
-    # Surround with try/finally for proper error catching
-    try:
-        # Start  logging
-        logger.info('Initializing ...')
-        # Get all file names in inpDir image collection
-        inpDir_files = [f.name for f in Path(inpDir).iterdir() if f.is_file() and "".join(f.suffixes) == '.ome.tif' ]
-        if Path(outDir).joinpath('flow.zarr').exists():
-           shutil.rmtree(str(Path(outDir).joinpath('flow.zarr')), ignore_errors=True)
-        root = zarr.group(store=str(Path(outDir).joinpath('flow.zarr')))
-        # Loop through files in inpDir image collection and process
+    # Start  logging
+    logger.info('Initializing ...')
+    # Get all file names in inpDir image collection
+    inpDir_files = [f.name for f in Path(inpDir).iterdir() if f.is_file() and "".join(f.suffixes) == '.ome.tif' ]
+        
+    root = zarr.group(store=str(Path(outDir).joinpath('flow.zarr')))
+    # Loop through files in inpDir image collection and process
+    processes = []
+    with ProcessPoolExecutor(num_threads) as executor:
         for f in inpDir_files:
             logger.info('Processing image %s ',f)
             br = BioReader(str(Path(inpDir).joinpath(f).absolute()))
-            tile_size = min(1024, br.X)
-            # Saving  Vector in chunks
+            tile_size = min(2048, br.X)
+            
+            # Initialize the zarr group, create datasets
             cluster = root.create_group(f)
             init_cluster_1 = cluster.create_dataset('vector', shape=(br.Y,br.X,br.Z,3,1),
-                                                    chunks=(tile_size, tile_size, 1, 3, 1))
+                                                    chunks=(1024, 1024, 1, 3, 1),
+                                                    dtype=np.float32)
             init_cluster_2 = cluster.create_dataset('lbl', shape=br.shape,
-                                                    chunks=(tile_size, tile_size, 1, 3, 1))
+                                                    chunks=(1024, 1024, 1, 3, 1),
+                                                    dtype=np.float32)
             cluster.attrs['metadata'] = str(br.metadata)
-            # Iterating over Z dimension
+            
             for z in range(br.Z):
                 for x in range(0, br.X, tile_size):
                     x_max = min([br.X, x + tile_size])
                     for y in range(0, br.Y, tile_size):
-                        y_max = min([br.Y, y + tile_size])
-                        flow = dynamics.labels_to_flows(br[y:y_max, x:x_max,z:z+1, 0,0].squeeze())
-                        flow_final = np.zeros((flow.shape[1], flow.shape[2], 1, 3, 1)).astype(np.float32)
-                        flow_final=flow[:,:,:,np.newaxis,np.newaxis].astype(np.float32)
-                        flow_final=flow_final.transpose((1,2,3,0,4))
-                        root[f]['vector'][y:y_max, x:x_max,z:z+1,0:3,0:1] = flow_final
-                        root[f]['lbl'][y:y_max, x:x_max,z:z+1, 0:1,0:1] = br[y:y_max, x:x_max,z:z+1, 0,0]
-
-    finally:
-        logger.info('Closing ')
-        # Exit the program
-        sys.exit()
+                        
+                        processes.append(executor.submit(flow_thread,
+                                                         str(Path(inpDir).joinpath(f).absolute()),
+                                                         str(Path(outDir).joinpath('flow.zarr')),
+                                                         x,y,z))
+                        
+            br.close()
+            
+        done, not_done = wait(processes,0)
+            
+        logger.info(f'Percent complete: {100*len(done)/len(processes):6.3f}%')
+        
+        while len(not_done) > 0:
+            
+            done, not_done = wait(processes,3)
+            
+            logger.info(f'Percent complete: {100*len(done)/len(processes):6.3f}%')
+            
+            

--- a/polus-label-to-vector-plugin/src/requirements.txt
+++ b/polus-label-to-vector-plugin/src/requirements.txt
@@ -1,4 +1,4 @@
-bfio==2.0.2
+bfio==2.1.0a6
 scipy==1.5.2
 zarr ==2.5.0
 numba==0.51.2


### PR DESCRIPTION
This fixes the issue of processing across tiles, and helps the plugin to scale more effectively using multiprocessing.

Parts of the code that need to be cleaned up include removing matplotlib and any other extraneous packages and making indexing variables in the flow_thread function easier to understand.

I removed the `shutil.rmtree` function for removing a file if it exists, because the assumption should be that we are writing data to an empty directory. I think not checking to see if the file exists and letting the plugin throw an error is the correct implementation here.